### PR TITLE
fix(neo4j): fixed connection string const

### DIFF
--- a/lessons/nodejs-app-with-neo4j.md
+++ b/lessons/nodejs-app-with-neo4j.md
@@ -73,7 +73,7 @@ const neo4j = require("neo4j-driver");
 const CONNECTION_STRING =
   process.env.NEO4J_CONNECTION_STRING || "bolt://localhost:7687";
 
-const driver = neo4j.driver(NEO4J_CONNECTION_STRING);
+const driver = neo4j.driver(CONNECTION_STRING);
 
 async function init() {
   const app = express();
@@ -104,6 +104,8 @@ async function init() {
 
   app.use(express.static("./static"));
   app.listen(process.env.PORT || 3000);
+
+  console.log(`running on http://localhost:${PORT}`);
 }
 init();
 ```


### PR DESCRIPTION
Updated the Neo4j driver to read the correct connection string.  It was currently only reading from the environment variable and not the constant that was set.

I also added in the `console.log` at the end of the `init()` to indicate that the server was running.